### PR TITLE
Fixed issue with localization of local administrator group

### DIFF
--- a/Lumos/Public/Register-LumosScheduledTask.ps1
+++ b/Lumos/Public/Register-LumosScheduledTask.ps1
@@ -35,9 +35,14 @@ Function Register-LumosScheduledTask {
         $LumosArgument = $LumosArgument + " -DarkWallpaper '$DarkWallpaper'"
     }
     
+    # Get localized value for local administrator group
+    $adminSid = [System.Security.Principal.WellKnownSidType]::BuiltinAdministratorsSid
+    $adminSecId = New-Object System.Security.Principal.SecurityIdentifier($adminSid, $null)
+    $localizedAdminGroup = $adminSecId.Translate([System.Security.Principal.NTAccount]).Value
+
     $LumosAction = New-ScheduledTaskAction -Execute 'powershell.exe' -Argument $LumosArgument
     $UpdateAction = New-ScheduledTaskAction -Execute 'powershell.exe' -Argument "$ArgumentDefaults -Command Update-LumosScheduledTask"
-    $Principal = New-ScheduledTaskPrincipal -GroupId "BUILTIN\Administrators" -RunLevel Highest
+    $Principal = New-ScheduledTaskPrincipal -GroupId $localizedAdminGroup -RunLevel Highest
 
     New-ScheduledTask -Action $LumosAction,$UpdateAction -Principal $Principal | Register-ScheduledTask -TaskName 'Lumos' -Force
 


### PR DESCRIPTION
The group "BUILTIN\Administrators" is only available on systems with en-US locale. For example on a system using the de-DE (German) locale the name would be:  "VORDEFINIERT\Administratoren". 

Fortunately you can always get to the localized name of the local administrators group by translating it from the SecurityIdentifier object: http://dusan.kuzmanovic.net/2012/07/06/powershell-finding-built-in-administrators-group/ 