### PR TITLE
Update HKCU:\...\data value to consider Office 365 ProPlus; add Break

### DIFF
--- a/Lumos/Public/Invoke-Lumos.ps1
+++ b/Lumos/Public/Invoke-Lumos.ps1
@@ -173,8 +173,16 @@ Function Invoke-Lumos {
         }
 
         if ($IncludeOfficeProPlus) {
-            $proPlusThemeValue = if ($Lumos -eq 0) { 4 } else { 0 }
-
+            $proPlusThemeValue = if ($Lumos -eq 0) { 
+                4 
+            } else { 
+                if ("HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\O365ProPlusRetail*") {
+                    5
+                } else {
+                    0
+                }
+            }
+            
             Write-Verbose "Setting OfficeProPlus to $Status with value: $proPlusThemeValue .."
 
             Set-ItemProperty -Path $OfficeThemeRegKey -Name 'UI Theme' -Value $proPlusThemeValue -Type DWORD
@@ -187,6 +195,7 @@ Function Invoke-Lumos {
 
                     Set-ItemProperty -Path $identityPath -Name 'Data' -Value ([byte[]]($proPlusThemeValue, 0, 0, 0)) -Type Binary
                 }
+                Break
             }
         }
 

--- a/Lumos/Public/Invoke-Lumos.ps1
+++ b/Lumos/Public/Invoke-Lumos.ps1
@@ -176,7 +176,7 @@ Function Invoke-Lumos {
             $proPlusThemeValue = if ($Lumos -eq 0) { 
                 4 
             } else { 
-                if ("HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\O365ProPlusRetail*") {
+                if (Test-Path "HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\O365ProPlusRetail*") {
                     5
                 } else {
                     0


### PR DESCRIPTION
It appears that in the ProPlus version of Office *365*, the binary values for the "data" reg key are slightly different. 4 is still Dark, but 5 is Light (and 7 is Colorful, if you're curious). I added an If block to check if Office365ProPlus is installed, and if so, changed that value. I also added a Break in the Foreach loop once the valid key is found.